### PR TITLE
Hide console window on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ file(GLOB chewing-editor_src
     ${PROJECT_SOURCE_DIR}/src/view/*
     ${ui}
 )
-add_executable(chewing-editor ${chewing-editor_src} ${qt_resources})
+add_executable(chewing-editor WIN32 ${chewing-editor_src} ${qt_resources}) # on Windows, remove "WIN32" for a console window
 target_link_libraries(chewing-editor
     ${CHEWING_LIBRARIES}
     exporter


### PR DESCRIPTION
When double-click (to execute) `chewing-editor.exe`, there is a ugly console window, this patch take care (hide) of it:

![pic](https://cloud.githubusercontent.com/assets/9395168/13422668/2dfad0d2-dfd1-11e5-927e-fa764f919b6a.png)

Update: This issue exists solely on windows platform.