### PR TITLE
Update libchewing Requirement in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ increase input performance.
 
 *   [CMake](https://www.cmake.org/) >= 3.0.0
 *   gcc >= 4.8 or Visual Studio Express 2012
-*   [libchewing](https://github.com/chewing/libchewing)
+*   [libchewing](https://github.com/chewing/libchewing) >= 0.4.0
 *   Qt = 5
 *   Editor with [EditorConfig](http://editorconfig.org/) support
 


### PR DESCRIPTION
We depends on `libchewing >= 0.4.0` since closing issue https://github.com/chewing/chewing-editor/issues/26 .
Update the dependency in `README.md`.