### PR TITLE
Fix menu translation

### DIFF
--- a/ts/chewing-editor_en_US.ts
+++ b/ts/chewing-editor_en_US.ts
@@ -36,13 +36,18 @@
     <message>
         <location filename="../src/ui/ChewingEditor.ui" line="88"/>
         <location filename="../src/view/ChewingEditor.cpp" line="63"/>
-        <source>Import</source>
+        <source>&amp;Import</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../src/ui/ChewingEditor.ui" line="93"/>
         <location filename="../src/view/ChewingEditor.cpp" line="71"/>
-        <source>Export</source>
+        <source>&amp;Export</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/ChewingEditor.ui" line="108"/>
+        <source>E&amp;xit</source>
         <translation></translation>
     </message>
     <message>
@@ -58,6 +63,17 @@
     <message>
         <location filename="../src/ui/ChewingEditor.ui" line="103"/>
         <source>About Qt</source>
+        <translation></translation>
+    </message>
+    <!-- Dialog -->
+    <message>
+        <location filename="../src/view/ChewingEditor.cpp" line="63"/>
+        <source>Import</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/view/ChewingEditor.cpp" line="71"/>
+        <source>Export</source>
         <translation></translation>
     </message>
 </context>

--- a/ts/chewing-editor_zh_TW.ts
+++ b/ts/chewing-editor_zh_TW.ts
@@ -43,15 +43,18 @@
     </message>
     <message>
         <location filename="../src/ui/ChewingEditor.ui" line="88"/>
-        <location filename="../src/view/ChewingEditor.cpp" line="63"/>
-        <source>Import</source>
-        <translation>匯入</translation>
+        <source>&amp;Import</source>
+        <translation>匯入(&amp;I)</translation>
     </message>
     <message>
         <location filename="../src/ui/ChewingEditor.ui" line="93"/>
-        <location filename="../src/view/ChewingEditor.cpp" line="71"/>
-        <source>Export</source>
-        <translation>匯出</translation>
+        <source>&amp;Export</source>
+        <translation>匯出(&amp;E)</translation>
+    </message>
+    <message>
+        <location filename="../src/ui/ChewingEditor.ui" line="108"/>
+        <source>E&amp;xit</source>
+        <translation>離開(&amp;X)</translation>
     </message>
     <message>
         <source>Add phrase</source>
@@ -75,6 +78,17 @@
         <location filename="../src/ui/ChewingEditor.ui" line="103"/>
         <source>About Qt</source>
         <translation>關於 Qt</translation>
+    </message>
+    <!-- Dialog -->
+    <message>
+        <location filename="../src/view/ChewingEditor.cpp" line="63"/>
+        <source>Import</source>
+        <translation>匯入</translation>
+    </message>
+    <message>
+        <location filename="../src/view/ChewingEditor.cpp" line="71"/>
+        <source>Export</source>
+        <translation>匯出</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
After we added the shortcut on the menu items (at https://github.com/chewing/chewing-editor/commit/ac937289c37ea89dd9c4309330d802ffdbb69983), we have to separate menu items from dialog titles to fix https://github.com/chewing/chewing-editor/issues/76.