### PR TITLE
Allow gzip to always overwrite output file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,7 @@ if (HELP2MAN)
             OUTPUT
                 ${manpage}.gz
             COMMAND ${GZIP}
+                -f
                 ${manpage}
             DEPENDS
                 ${manpage}


### PR DESCRIPTION
This allow building process to run more smoothly (especially for building AUR package).