### PR TITLE
Update translation and quote the filename while importing/exporting

### DIFF
--- a/src/view/Notification.cpp
+++ b/src/view/Notification.cpp
@@ -37,11 +37,11 @@ void Notification::notifyImportCompleted(
     if (result) {
         setText(
             tr("%1 %2 %3")
-                .arg(tr("Import %1 successful.").arg(path))
+                .arg(tr("Import \"%1\" successful.").arg(path))
                 .arg(tr("%n phrase(s) are imported.", 0, imported))
                 .arg(tr("Total %n user phrase(s).", 0, total)));
     } else {
-        setText(tr("Import %1 failed.").arg(path));
+        setText(tr("Import \"%1\" failed.").arg(path));
     }
 }
 
@@ -55,10 +55,10 @@ void Notification::notifyExportCompleted(
     if (result) {
         setText(
             tr("%1 %2")
-                .arg(tr("Export %1 successful.").arg(path))
+                .arg(tr("Export \"%1\" successful.").arg(path))
                 .arg(tr("%n phrase(s) are exported.", 0, exported)));
     } else {
-        setText(tr("Export %1 failed.").arg(path));
+        setText(tr("Export \"%1\" failed.").arg(path));
     }
 }
 

--- a/ts/chewing-editor_en_US.ts
+++ b/ts/chewing-editor_en_US.ts
@@ -9,7 +9,7 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="71"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="75"/>
         <source>File</source>
         <translation></translation>
     </message>
@@ -29,22 +29,22 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="80"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="84"/>
         <source>Help</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="90"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="94"/>
         <source>&amp;Import</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="95"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="99"/>
         <source>&amp;Export</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="110"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="114"/>
         <source>E&amp;xit</source>
         <translation></translation>
     </message>
@@ -54,12 +54,12 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="100"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="104"/>
         <source>About Chewing editor</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="105"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="109"/>
         <source>About Qt</source>
         <translation></translation>
     </message>
@@ -82,18 +82,8 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/view/Notification.cpp" line="44"/>
-        <source>Import %1 failed.</source>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="../src/view/Notification.cpp" line="57"/>
         <source>%1 %2</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../src/view/Notification.cpp" line="40"/>
-        <source>Import %1 successful.</source>
         <translation></translation>
     </message>
     <message numerus="yes">
@@ -112,11 +102,6 @@
             <numerusform>Total %n user phrases.</numerusform>
         </translation>
     </message>
-    <message>
-        <location filename="../src/view/Notification.cpp" line="58"/>
-        <source>Export %1 successful.</source>
-        <translation></translation>
-    </message>
     <message numerus="yes">
         <location filename="../src/view/Notification.cpp" line="59"/>
         <source>%n phrase(s) are exported.</source>
@@ -126,8 +111,23 @@
         </translation>
     </message>
     <message>
+        <location filename="../src/view/Notification.cpp" line="40"/>
+        <source>Import &quot;%1&quot; successful.</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/view/Notification.cpp" line="44"/>
+        <source>Import &quot;%1&quot; failed.</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/view/Notification.cpp" line="58"/>
+        <source>Export &quot;%1&quot; successful.</source>
+        <translation></translation>
+    </message>
+    <message>
         <location filename="../src/view/Notification.cpp" line="61"/>
-        <source>Export %1 failed.</source>
+        <source>Export &quot;%1&quot; failed.</source>
         <translation></translation>
     </message>
     <message>

--- a/ts/chewing-editor_zh_TW.ts
+++ b/ts/chewing-editor_zh_TW.ts
@@ -13,13 +13,13 @@
         <translation type="vanished">過濾</translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="71"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="75"/>
         <source>File</source>
         <translation>檔案</translation>
     </message>
     <message>
         <source>Edit</source>
-        <translation type="vanished">修改</translation>
+        <translation type="vanished">編輯</translation>
     </message>
     <message>
         <location filename="../src/ui/ChewingEditor.ui" line="27"/>
@@ -37,22 +37,22 @@
         <translation>搜尋</translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="80"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="84"/>
         <source>Help</source>
         <translation>求助</translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="90"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="94"/>
         <source>&amp;Import</source>
         <translation>匯入(&amp;I)</translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="95"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="99"/>
         <source>&amp;Export</source>
         <translation>匯出(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="110"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="114"/>
         <source>E&amp;xit</source>
         <translation>離開(&amp;X)</translation>
     </message>
@@ -70,12 +70,12 @@
         <translation>更新</translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="100"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="104"/>
         <source>About Chewing editor</source>
         <translation>關於新酷音詞庫編輯器</translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="105"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="109"/>
         <source>About Qt</source>
         <translation>關於 Qt</translation>
     </message>
@@ -98,9 +98,8 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/view/Notification.cpp" line="40"/>
         <source>Import %1 successful.</source>
-        <translation>匯入 「%1」成功。</translation>
+        <translation type="vanished">匯入 &quot;%1&quot; 成功。</translation>
     </message>
     <message numerus="yes">
         <location filename="../src/view/Notification.cpp" line="41"/>
@@ -117,19 +116,9 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/view/Notification.cpp" line="44"/>
-        <source>Import %1 failed.</source>
-        <translation>無法匯入 %1。</translation>
-    </message>
-    <message>
         <location filename="../src/view/Notification.cpp" line="57"/>
         <source>%1 %2</source>
         <translation></translation>
-    </message>
-    <message>
-        <location filename="../src/view/Notification.cpp" line="58"/>
-        <source>Export %1 successful.</source>
-        <translation>匯出 %1 成功。</translation>
     </message>
     <message numerus="yes">
         <location filename="../src/view/Notification.cpp" line="59"/>
@@ -139,9 +128,24 @@
         </translation>
     </message>
     <message>
+        <location filename="../src/view/Notification.cpp" line="40"/>
+        <source>Import &quot;%1&quot; successful.</source>
+        <translation>匯入 &quot;%1&quot; 成功。</translation>
+    </message>
+    <message>
+        <location filename="../src/view/Notification.cpp" line="44"/>
+        <source>Import &quot;%1&quot; failed.</source>
+        <translation>無法匯入 &quot;%1&quot;。</translation>
+    </message>
+    <message>
+        <location filename="../src/view/Notification.cpp" line="58"/>
+        <source>Export &quot;%1&quot; successful.</source>
+        <translation>匯出 &quot;%1&quot; 成功。</translation>
+    </message>
+    <message>
         <location filename="../src/view/Notification.cpp" line="61"/>
-        <source>Export %1 failed.</source>
-        <translation>匯出 %1 失敗。</translation>
+        <source>Export &quot;%1&quot; failed.</source>
+        <translation>匯出 &quot;%1&quot; 失敗。</translation>
     </message>
     <message>
         <location filename="../src/view/Notification.cpp" line="69"/>


### PR DESCRIPTION
Close #95.
BTW, `edit` is vanished but I still update it's translation to `編輯`.