### PR TITLE
Grab focus to phrase input widget on dialog open.

### DIFF
--- a/src/view/UserphraseDialog.cpp
+++ b/src/view/UserphraseDialog.cpp
@@ -59,4 +59,6 @@ void UserphraseDialog::setText(const QString& phrase, const QString& bopomofo)
 {
     ui_.get()->phrase->setText(phrase);
     ui_.get()->bopomofo->setText(bopomofo);
+
+    ui_->phrase->setFocus(Qt::PopupFocusReason);
 }


### PR DESCRIPTION
Ideally `setFocus` should be placed at `UserphraseDialog` ctor, but I'm too lazy to refactor the whole class...