### PR TITLE
Make menu more natively on Mac OS X

### DIFF
--- a/src/ui/ChewingEditor.ui
+++ b/src/ui/ChewingEditor.ui
@@ -103,15 +103,24 @@
    <property name="text">
     <string>About Chewing editor</string>
    </property>
+   <property name="menuRole">
+    <enum>QAction::AboutRole</enum>
+   </property>
   </action>
   <action name="actionAboutQt">
    <property name="text">
     <string>About Qt</string>
    </property>
+   <property name="menuRole">
+    <enum>QAction::AboutQtRole</enum>
+   </property>
   </action>
   <action name="actionExit">
    <property name="text">
     <string>E&amp;xit</string>
+   </property>
+   <property name="menuRole">
+    <enum>QAction::QuitRole</enum>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This will close #129.

Before:

![2016-03-25 10 53 30](https://cloud.githubusercontent.com/assets/841969/14039499/1210fe8a-f298-11e5-9734-3763f5816c50.png)
![2016-03-25 14 44 59](https://cloud.githubusercontent.com/assets/841969/14039509/2cea5184-f298-11e5-8e9d-436418d5325f.png)
![2016-03-25 14 45 03](https://cloud.githubusercontent.com/assets/841969/14039510/316cccfa-f298-11e5-9732-9c1ac17ce6a6.png)

After:

![2016-03-25 14 40 51](https://cloud.githubusercontent.com/assets/841969/14039492/023e9922-f298-11e5-8d3d-10513ea65cc2.png)
![2016-03-25 14 40 59](https://cloud.githubusercontent.com/assets/841969/14039496/07446348-f298-11e5-8a60-8f4ad2fdce16.png)

ref: http://www.slideshare.net/qtbynokia/how-to-make-your-qt-app-look-native

Notice that `chewing-editor` only can be changed in other way, I'll send a patch later.