### PR TITLE
Add shortcuts

### DIFF
--- a/src/view/ChewingEditor.cpp
+++ b/src/view/ChewingEditor.cpp
@@ -48,9 +48,21 @@ ChewingEditor::ChewingEditor(QWidget *parent)
     setupAboutWidget();
 
     // exit action
+    shortcut_exit_ = new QShortcut(QKeySequence::Quit, this);
+    connect(
+        shortcut_exit_, SIGNAL(activated()),
+        SLOT(close())
+    );
     connect(
         ui_.get()->actionExit, SIGNAL(triggered()),
         SLOT(close())
+    );
+
+    // modify action
+    shortcut_modify_ = new QShortcut(Qt::Key_Return, this);
+    connect(
+        shortcut_modify_, SIGNAL(activated()),
+        ui_.get()->userphraseView, SLOT(showModifyUserphraseDialog())
     );
 }
 
@@ -140,6 +152,12 @@ void ChewingEditor::setupFileSelection()
 
 void ChewingEditor::setupImport()
 {
+    shortcut_import_ = new QShortcut(Qt::CTRL + Qt::Key_I, this);
+    connect(
+        shortcut_import_, SIGNAL(activated()),
+        this, SLOT(selectImportFile())
+    );
+
     connect(
         ui_.get()->actionImport, SIGNAL(triggered()),
         this, SLOT(selectImportFile())
@@ -153,6 +171,12 @@ void ChewingEditor::setupImport()
 
 void ChewingEditor::setupExport()
 {
+    shortcut_export_ = new QShortcut(Qt::CTRL + Qt::Key_E, this);
+    connect(
+        shortcut_export_, SIGNAL(activated()),
+        this, SLOT(selectExportFile())
+    );
+
     connect(
         ui_.get()->actionExport, SIGNAL(triggered()),
         this, SLOT(selectExportFile())
@@ -166,6 +190,12 @@ void ChewingEditor::setupExport()
 
 void ChewingEditor::setupAdd()
 {
+    shortcut_add_ = new QShortcut(QKeySequence::New, this);
+    connect(
+        shortcut_add_, SIGNAL(activated()),
+        ui_.get()->userphraseView, SLOT(showAddUserphraseDialog())
+    );
+
     connect(
         ui_.get()->addButton, SIGNAL(pressed()),
         ui_.get()->userphraseView, SLOT(showAddUserphraseDialog())
@@ -179,6 +209,12 @@ void ChewingEditor::setupAdd()
 
 void ChewingEditor::setupRemove()
 {
+    shortcut_remove_ = new QShortcut(QKeySequence::Delete, this);
+    connect(
+        shortcut_remove_, SIGNAL(activated()),
+        ui_.get()->userphraseView, SLOT(remove())
+    );
+
     connect(
         ui_.get()->removeButton, SIGNAL(pressed()),
         ui_.get()->userphraseView, SLOT(remove())
@@ -192,6 +228,12 @@ void ChewingEditor::setupRemove()
 
 void ChewingEditor::setupRefresh()
 {
+    shortcut_refresh_ = new QShortcut(Qt::CTRL + Qt::Key_R, this);
+    connect(
+        shortcut_refresh_, SIGNAL(activated()),
+        model_, SLOT(refresh())
+    );
+
     connect(
         ui_.get()->refreshButton, SIGNAL(pressed()),
         model_, SLOT(refresh())

--- a/src/view/ChewingEditor.h
+++ b/src/view/ChewingEditor.h
@@ -21,6 +21,7 @@
 
 #include <memory>
 
+#include <QShortcut>
 #include <QFileDialog>
 #include <QMainWindow>
 
@@ -73,4 +74,8 @@ private:
 
     QFileDialog *fileDialog_;
     DialogType dialogType_;
+
+    QShortcut *shortcut_add_, *shortcut_modify_, *shortcut_remove_,
+        *shortcut_refresh_, *shortcut_import_, *shortcut_export_,
+        *shortcut_exit_;
 };


### PR DESCRIPTION
....for the following actions: Add, Remove,Modify, Refresh, Import, Export. Quit

|Action|Keys| Test in linux|
| ------------- |:-------------:| -----:|
|Add|QKeySequence::New|CTRL+N|
|Remove|QKeySequence::Delete|Delete|
|Modify|Qt::Key_Return|Enter|
|Refresh|Qt::CTRL + Qt::Key_R|CTRL+R|
|Import|Qt::CTRL + Qt::Key_I|CTRL+I|
|Export|Qt::CTRL + Qt::Key_E|CTRL+E|
|Quit|QKeySequence::Quit|CTRL+Q|

doc: https://doc.qt.io/qt-5/qkeysequence.html#StandardKey-enum