### PR TITLE
 Phrase can be preserved when the "add" step in "modify" is failed.

### DIFF
--- a/src/model/UserphraseModel.cpp
+++ b/src/model/UserphraseModel.cpp
@@ -52,6 +52,7 @@ UserphraseModel::UserphraseModel(QObject *parent, const char *path)
     :QAbstractListModel{parent}
     ,ctx_{chewing_new2(nullptr, path, logger, nullptr), chewing_delete}
     ,userphrase_{}
+    ,addresult_(1)
 {
     if (!ctx_) {
         // FIXME: Report error here
@@ -199,7 +200,7 @@ QString UserphraseModel::checkBopomofo(const QString &bopomofo) const
     QString replaceBopomofo = bopomofo;
     replaceBopomofo.replace(QString::fromUtf8("ㄧ"),QString::fromUtf8("ㄧ"));
     replaceBopomofo.replace(QString::fromUtf8("Y"),QString::fromUtf8("ㄚ"));
-    
+
     return replaceBopomofo;
 }
 
@@ -210,6 +211,8 @@ void UserphraseModel::add(const QString &phrase, const QString &bopomofo)
         ctx_.get(),
         phrase.toUtf8().constData(),
         replaceBopomofo.toUtf8().constData());
+
+    addresult_ = ret;
 
     if (ret > 0) {
         emit beginResetModel();

--- a/src/model/UserphraseModel.h
+++ b/src/model/UserphraseModel.h
@@ -45,6 +45,7 @@ public:
 
     const Userphrase *getUserphrase(const QModelIndex& idx);
 
+    int getAddResult() const {return addresult_;}
 signals:
     void importCompleted(
         bool result,
@@ -72,4 +73,5 @@ private:
 
     std::unique_ptr<ChewingContext, void (*)(ChewingContext*)> ctx_;
     UserphraseSet userphrase_;
+    int addresult_;
 };

--- a/src/view/UserphraseView.cpp
+++ b/src/view/UserphraseView.cpp
@@ -26,6 +26,8 @@ UserphraseView::UserphraseView(QWidget *parent)
     :QListView{parent}
     ,UserphraseDialog_{new UserphraseDialog{this}}
     ,menu_(new UserphraseViewMenu{this})
+    ,originalPhrase{new QString()}
+    ,originalBopomofo{new QString()}
 {
     setupContextMenu();
     setupAddUserphraseDialog();
@@ -56,6 +58,10 @@ void UserphraseView::showModifyUserphraseDialog()
 
     UserphraseDialog_->setText(userphrase->phrase_, userphrase->bopomofo_);
     UserphraseDialog_->setWindowTitle(tr("Modify phrase"));
+
+    *originalPhrase = userphrase->phrase_;
+    *originalBopomofo = userphrase->bopomofo_;
+
     emit UserphraseDialog_->exec();
 }
 
@@ -75,6 +81,12 @@ void UserphraseView::addPhrase(int result)
     }
 
     emit model()->add(phrase, bopomofo);
+
+    if (dialogType_ == DIALOG_MODIFY) {
+        if (model()->sourceModel()->getAddResult() <= 0) {
+            emit model()->add(originalPhrase, originalBopomofo);
+        }
+    }
 }
 
 void UserphraseView::remove()

--- a/src/view/UserphraseView.h
+++ b/src/view/UserphraseView.h
@@ -64,4 +64,7 @@ private:
     UserphraseViewMenu *menu_;
 
     bool dialogType_;
+
+    std::shared_ptr<QString> originalPhrase;
+    std::shared_ptr<QString> originalBopomofo;
 };


### PR DESCRIPTION
This will close #75  #109 

When the "add" step is failed, the function will re-add the original phrase back.

This is my first pull request, wherever I can improve, please tell me.