### PR TITLE
Add chewing-editor.dSYM into .gitignore for OS X builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 /ui_*.h
 /Testing/
 /coverage*
+/chewing-editor.dSYM/


### PR DESCRIPTION
On OS X, cmake will generate `chewing-editor.dSYM` folder to place information for the executable.