### PR TITLE
Fix gitignore for cmake/ on OS X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 CMake*
 !CMakeLists.txt
+!/cmake
 *.cmake
+!/cmake/*.cmake
 Makefile
 
 gmock/


### PR DESCRIPTION
On OS X, the filesystem is case-insensitive, so we need to care about the `cmake/` directory after https://github.com/chewing/chewing-editor/pull/130.