### PR TITLE
Undo function for phrase deletions and translation for undo function

### DIFF
--- a/src/model/UserphraseModel.cpp
+++ b/src/model/UserphraseModel.cpp
@@ -105,6 +105,7 @@ void UserphraseModel::remove(QModelIndexList indexList)
             userphrase_[index].phrase_.toUtf8().constData(),
             userphrase_[index].bopomofo_.toUtf8().constData());
         if (ret > 0) {
+            removerecord_.push_back(Userphrase{userphrase_[index]});
             // FIXME: std::vector::erase is an inefficient operation.
             userphrase_.erase(userphrase_.begin() + index);
         } else {
@@ -232,4 +233,15 @@ void UserphraseModel::add(const QString &phrase, const QString &bopomofo)
 const Userphrase *UserphraseModel::getUserphrase(const QModelIndex& idx)
 {
     return &userphrase_[idx.row()];
+}
+
+void UserphraseModel::undo()
+{
+    if (!removerecord_.empty()) {
+        auto last = removerecord_.end() - 1;
+        const QString phrase = last->display_;
+        add(last->phrase_, last->bopomofo_);
+        removerecord_.erase(last);
+        emit undoCompleted(phrase);
+    }
 }

--- a/src/model/UserphraseModel.h
+++ b/src/model/UserphraseModel.h
@@ -59,7 +59,8 @@ signals:
     void addNewPhraseCompleted(const Userphrase& userphrase);
     void removePhraseCompleted(size_t count);
     void refreshCompleted(size_t count);
-    void addNewPhraseFailed();
+    void addNewPhraseFailed();    
+    void undoCompleted(const QString &phrase);
 
 public slots:
     void refresh();
@@ -67,6 +68,7 @@ public slots:
     void importUserphrase(std::shared_ptr<UserphraseImporter> importer);
     void exportUserphrase(std::shared_ptr<UserphraseExporter> exporter);
     void remove(QModelIndexList indexList);
+    void undo();
 
 private:
     void add(const QString &phrase, const QString &bopomofo);
@@ -74,5 +76,6 @@ private:
 
     std::unique_ptr<ChewingContext, void (*)(ChewingContext*)> ctx_;
     UserphraseSet userphrase_;
+    std::vector<Userphrase> removerecord_;
     int addresult_;
 };

--- a/src/ui/ChewingEditor.ui
+++ b/src/ui/ChewingEditor.ui
@@ -36,23 +36,30 @@
      </widget>
     </item>
     <item row="0" column="2">
+     <widget class="QPushButton" name="undoButton">
+      <property name="text">
+       <string>Undo</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="3">
      <widget class="QPushButton" name="refreshButton">
       <property name="text">
        <string>Refresh</string>
       </property>
      </widget>
     </item>
-    <item row="0" column="3">
+    <item row="0" column="4">
      <widget class="QLineEdit" name="userphraseFilter">
       <property name="placeholderText">
        <string>Search</string>
       </property>
      </widget>
     </item>
-    <item row="1" column="0" colspan="4">
+    <item row="1" column="0" colspan="5">
      <widget class="Notification" name="notification"/>
     </item>
-    <item row="2" column="0" colspan="4">
+    <item row="2" column="0" colspan="5">
      <widget class="UserphraseView" name="userphraseView">
       <property name="selectionMode">
        <enum>QAbstractItemView::ExtendedSelection</enum>

--- a/src/view/ChewingEditor.cpp
+++ b/src/view/ChewingEditor.cpp
@@ -46,6 +46,7 @@ ChewingEditor::ChewingEditor(QWidget *parent)
     setupAdd();
     setupRemove();
     setupRefresh();
+    setupUndo();
     setupFilter();
     setupAboutWidget();
 
@@ -306,6 +307,19 @@ void ChewingEditor::setupRefresh()
     );
 
     emit model_->refresh();
+}
+
+void ChewingEditor::setupUndo()
+{
+    connect(
+        ui_.get()->undoButton, SIGNAL(pressed()),
+        model_, SLOT(undo())
+    );
+
+    connect(
+        model_, SIGNAL(undoCompleted(const QString&)),
+        ui_.get()->notification, SLOT(notifyUndoCompleted(const QString&))
+    );
 }
 
 void ChewingEditor::setupFilter()

--- a/src/view/ChewingEditor.h
+++ b/src/view/ChewingEditor.h
@@ -62,6 +62,7 @@ private:
     void setupAdd();
     void setupRemove();
     void setupRefresh();
+    void setupUndo();
     void setupFilter();
     void setupAboutWidget();
     void importUserphrase(const QString& file);

--- a/src/view/Notification.cpp
+++ b/src/view/Notification.cpp
@@ -88,3 +88,8 @@ void Notification::notifyAddNewPhraseFailed()
 {
     setText(tr("Add new phrase failed. Please enter the bopomofo for each word and try again."));
 }
+
+void Notification::notifyUndoCompleted(const QString &phrase)
+{
+    setText(tr("Undo completed. Revert %1.").arg(phrase));
+}

--- a/src/view/Notification.h
+++ b/src/view/Notification.h
@@ -40,4 +40,5 @@ public slots:
     void notifyRemovePhraseCompleted(size_t count);
     void notifyRefreshCompleted(size_t count);
     void notifyAddNewPhraseFailed();
+    void notifyUndoCompleted(const QString &phrase);
 };

--- a/ts/chewing-editor_en_US.ts
+++ b/ts/chewing-editor_en_US.ts
@@ -9,7 +9,7 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="75"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="82"/>
         <source>File</source>
         <translation></translation>
     </message>
@@ -24,42 +24,47 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="48"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="55"/>
         <source>Search</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="84"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="91"/>
         <source>Help</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="94"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="101"/>
         <source>&amp;Import</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="99"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="106"/>
         <source>&amp;Export</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="114"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="127"/>
         <source>E&amp;xit</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="41"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="48"/>
         <source>Refresh</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="104"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="41"/>
+        <source>Undo</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/ChewingEditor.ui" line="111"/>
         <source>About Chewing editor</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="109"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="119"/>
         <source>About Qt</source>
         <translation></translation>
     </message>
@@ -154,6 +159,11 @@
     <message>
         <location filename="../src/view/Notification.cpp" line="89"/>
         <source>Add new phrase failed. Please enter the bopomofo for each word and try again.</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/view/Notification.cpp" line="94"/>
+        <source>Undo completed. Revert %1.</source>
         <translation></translation>
     </message>
 </context>

--- a/ts/chewing-editor_zh_TW.ts
+++ b/ts/chewing-editor_zh_TW.ts
@@ -13,7 +13,7 @@
         <translation type="vanished">過濾</translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="75"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="82"/>
         <source>File</source>
         <translation>檔案</translation>
     </message>
@@ -32,27 +32,27 @@
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="48"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="55"/>
         <source>Search</source>
         <translation>搜尋</translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="84"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="91"/>
         <source>Help</source>
         <translation>求助</translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="94"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="101"/>
         <source>&amp;Import</source>
         <translation>匯入(&amp;I)</translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="99"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="106"/>
         <source>&amp;Export</source>
         <translation>匯出(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="114"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="127"/>
         <source>E&amp;xit</source>
         <translation>離開(&amp;X)</translation>
     </message>
@@ -65,17 +65,22 @@
         <translation type="vanished">刪除詞彙</translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="41"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="48"/>
         <source>Refresh</source>
         <translation>更新</translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="104"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="41"/>
+        <source>Undo</source>
+        <translation>復原</translation>
+    </message>
+    <message>
+        <location filename="../src/ui/ChewingEditor.ui" line="111"/>
         <source>About Chewing editor</source>
         <translation>關於新酷音詞庫編輯器</translation>
     </message>
     <message>
-        <location filename="../src/ui/ChewingEditor.ui" line="109"/>
+        <location filename="../src/ui/ChewingEditor.ui" line="119"/>
         <source>About Qt</source>
         <translation>關於 Qt</translation>
     </message>
@@ -170,6 +175,11 @@
         <location filename="../src/view/Notification.cpp" line="89"/>
         <source>Add new phrase failed. Please enter the bopomofo for each word and try again.</source>
         <translation>新增詞彙失敗。請輸入每個字的注音後再試一次。</translation>
+    </message>
+    <message>
+        <location filename="../src/view/Notification.cpp" line="94"/>
+        <source>Undo completed. Revert %1.</source>
+        <translation>復原完成。復原 「%1」。</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
The undo function only supports reverting of phrase deletions.
It supports multiple deletions but users have to revert them one by one.

I edited the translation file for the new feature, and updated several line numbers to match
the changing of ui and cpp files.

Is there any missing place, please tell me and I will improve it.
Thanks!

Resolves: #133 