### PR TITLE
Notify user when add phrase failed

### DIFF
--- a/src/model/UserphraseModel.cpp
+++ b/src/model/UserphraseModel.cpp
@@ -225,6 +225,7 @@ void UserphraseModel::add(const QString &phrase, const QString &bopomofo)
     } else {
         qWarning() << "chewing_userphrase_add() returns" << ret;
         refresh();
+        emit addNewPhraseFailed();
     }
 }
 

--- a/src/model/UserphraseModel.h
+++ b/src/model/UserphraseModel.h
@@ -59,6 +59,7 @@ signals:
     void addNewPhraseCompleted(const Userphrase& userphrase);
     void removePhraseCompleted(size_t count);
     void refreshCompleted(size_t count);
+    void addNewPhraseFailed();
 
 public slots:
     void refresh();

--- a/src/view/ChewingEditor.cpp
+++ b/src/view/ChewingEditor.cpp
@@ -261,6 +261,11 @@ void ChewingEditor::setupAdd()
         model_, SIGNAL(addNewPhraseCompleted(const Userphrase&)),
         ui_.get()->notification, SLOT(notifyAddNewPhraseCompleted(const Userphrase&))
     );
+
+    connect(
+        model_, SIGNAL(addNewPhraseFailed()),
+        ui_.get()->notification, SLOT(notifyAddNewPhraseFailed())
+    );
 }
 
 void ChewingEditor::setupRemove()

--- a/src/view/Notification.cpp
+++ b/src/view/Notification.cpp
@@ -83,3 +83,8 @@ void Notification::notifyRefreshCompleted(size_t count)
 
     setText(tr("Refresh completed. Total %n user phrase(s).", 0, count));
 }
+
+void Notification::notifyAddNewPhraseFailed()
+{
+    setText(tr("Add new phrase failed. Please enter the bopomofo for each word and try again."));
+}

--- a/src/view/Notification.h
+++ b/src/view/Notification.h
@@ -39,4 +39,5 @@ public slots:
     void notifyAddNewPhraseCompleted(const Userphrase& userphrase);
     void notifyRemovePhraseCompleted(size_t count);
     void notifyRefreshCompleted(size_t count);
+    void notifyAddNewPhraseFailed();
 };

--- a/ts/chewing-editor_en_US.ts
+++ b/ts/chewing-editor_en_US.ts
@@ -151,6 +151,11 @@
             <numerusform>Refresh completed. Total %n user phrases.</numerusform>
         </translation>
     </message>
+    <message>
+        <location filename="../src/view/Notification.cpp" line="89"/>
+        <source>Add new phrase failed. Please enter the bopomofo for each word and try again.</source>
+        <translation></translation>
+    </message>
 </context>
 <context>
     <name>UserphraseDialog</name>

--- a/ts/chewing-editor_zh_TW.ts
+++ b/ts/chewing-editor_zh_TW.ts
@@ -166,6 +166,11 @@
             <numerusform>更新完成。共有 %n 個詞彙。</numerusform>
         </translation>
     </message>
+    <message>
+        <location filename="../src/view/Notification.cpp" line="89"/>
+        <source>Add new phrase failed. Please enter the bopomofo for each word and try again.</source>
+        <translation>新增詞彙失敗。請輸入每個字的注音後再試一次。</translation>
+    </message>
 </context>
 <context>
     <name>UserphraseDialog</name>


### PR DESCRIPTION
Close #160

When user add phrase fail, there will be a notification tell user the movement is failed:
![default](https://cloud.githubusercontent.com/assets/17449636/14409286/2440427c-ff41-11e5-9ccd-51b5de6508ee.PNG)
![2](https://cloud.githubusercontent.com/assets/17449636/14409287/2440bc0c-ff41-11e5-9665-bcbfb542b626.PNG)
(The phrase still add in editor because of the auto-learning function in libchewing)

Does the notification need to show the content of the phrase add failed?