### PR TITLE
fix invalid Version value in desktop file.

### DIFF
--- a/chewing-editor.desktop.in
+++ b/chewing-editor.desktop.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=@PROJECT_VERSION@
+Version=1.0
 Type=Application
 Name=Chewing Editor
 Comment=Chewing Userphrase Editor


### PR DESCRIPTION
Version value should be 1.0, not project version:
See https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s05.html

Note that Version is not a required key and can be removed instead.
Close #180.