### PR TITLE
Add Mageia install info

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ increase input performance.
 
 # Install
 * Arch Linux: install from AUR: [Stable release](https://aur.archlinux.org/packages/chewing-editor/), [Development](https://aur.archlinux.org/packages/chewing-editor-git/)
+* Mageia: install from urpmi: available in cauldron, Mageia 6 and later. 
 
 # Development
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ increase input performance.
 
 # Install
 * Arch Linux: install from AUR: [Stable release](https://aur.archlinux.org/packages/chewing-editor/), [Development](https://aur.archlinux.org/packages/chewing-editor-git/)
-* Mageia: install from urpmi: available in cauldron, Mageia 6 and later. 
+* Mageia: install via 'urpmi chewing-editor' - available in cauldron, Mageia 6 and later. 
 
 # Development
 


### PR DESCRIPTION
rpm now available in cauldron (development branch) and will be in Mageia 6 (next stable release).