### PR TITLE
Fix TravisCI build failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,18 @@ matrix:
 git:
     depth: 1
 
-before_install:
+# opt-in Ubuntu Trusty
+sudo: required
+dist: trusty
+
+install:
     - sudo pip install cpp-coveralls
-    - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
-    - sudo add-apt-repository --yes ppa:ubuntu-sdk-team/ppa
     - sudo add-apt-repository --yes ppa:chewing/chewing
-    - sudo add-apt-repository --yes ppa:chewing/travis-ci
     - sudo apt-get update
       # FIXME: We need to instal cmake-data manually to prevent cmake upgrade fails.
-    - sudo apt-get install --yes cmake-data cmake gcc-4.8 g++-4.8 help2man libchewing3-dev pkg-config qt5-default qttools5-dev-tools
-    - sudo ln -fs /usr/bin/gcc-4.8 /usr/bin/gcc
+    - sudo apt-get install --yes cmake cmake-data pkg-config help2man qt5-default qttools5-dev-tools libchewing3-dev
     - gcc --version
-    - sudo ln -fs /usr/bin/g++-4.8 /usr/bin/g++
     - g++ --version
-    - sudo ln -fs /usr/bin/gcov-4.8 /usr/bin/gcov
     - gcov --version
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ git:
 # opt-in Ubuntu Trusty
 sudo: required
 dist: trusty
+cache: ccache
 
 install:
     - sudo pip install cpp-coveralls
@@ -19,6 +20,7 @@ install:
     - sudo apt-get update
       # FIXME: We need to instal cmake-data manually to prevent cmake upgrade fails.
     - sudo apt-get install --yes cmake cmake-data pkg-config help2man qt5-default qttools5-dev-tools libchewing3-dev
+    - ccache -V && ccache --show-stats && ccache --zero-stats && export use_ccache=true
     - gcc --version
     - g++ --version
     - gcov --version
@@ -30,3 +32,6 @@ script:
 
 after_success:
     - if [ x$COVERALLS == xyes ]; then coveralls --exclude gmock --exclude test --exclude-pattern '.*CMake[^/]+\.c(?:pp)?' --exclude-pattern '.*_automoc.cpp'; fi
+
+after_script:
+  - if [ "$use_ccache" = true ]; then ccache --show-stats ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ install:
     - sudo pip install cpp-coveralls
     - sudo add-apt-repository --yes ppa:chewing/chewing
     - sudo apt-get update
-      # FIXME: We need to instal cmake-data manually to prevent cmake upgrade fails.
-    - sudo apt-get install --yes cmake cmake-data pkg-config help2man qt5-default qttools5-dev-tools libchewing3-dev
+    - sudo apt-get install --yes cmake help2man qt5-default qttools5-dev-tools libchewing3-dev
     - ccache -V && ccache --show-stats && ccache --zero-stats && export use_ccache=true
     - gcc --version
     - g++ --version


### PR DESCRIPTION
* Fix TravisCI build fail
* Opt-in to use Ubuntu Trusty as building platform, see: https://docs.travis-ci.com/user/trusty-ci-environment
* Enable building with ccache on TravisCI, see: https://docs.travis-ci.com/user/caching/#ccache-cache
* By default, the following packages are already newest in the Trusty image: cmake-data, pkg-config. So there is no need to install them manually.