### PR TITLE
Fix dialogType display wrong value in debug mode

### DIFF
--- a/src/view/ChewingEditor.cpp
+++ b/src/view/ChewingEditor.cpp
@@ -60,9 +60,9 @@ ChewingEditor::~ChewingEditor()
 
 void ChewingEditor::execFileDialog(DialogType type)
 {
-    qDebug() << "dialogType_ = " << dialogType_;
-
     dialogType_ = type;
+
+    qDebug() << "dialogType_ = " << dialogType_;
 
     switch (dialogType_) {
     case DIALOG_IMPORT:


### PR DESCRIPTION
I found that it can't show the correct dialogType value, because it print log before changed the value.