### PR TITLE
Fix remove phrase incorrect behavior [issue #192]

### DIFF
--- a/src/view/ChewingEditor.cpp
+++ b/src/view/ChewingEditor.cpp
@@ -193,20 +193,22 @@ void ChewingEditor::showAbout()
 
 void ChewingEditor::showDeleteConfirmWindow()
 {
-    QString text = tr("Do you want to delete this phrase?");
+    if (model_->rowCount()){
+        QString text = tr("Do you want to delete this phrase?");
 
-    QMessageBox deleteBox(this);
-    deleteBox.setWindowTitle(tr("Delete phrase"));
-    deleteBox.setText(text);
-    deleteBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-    deleteBox.setDefaultButton(QMessageBox::No);
-
-    connect(
-        deleteBox.button(QMessageBox::Yes), SIGNAL(clicked()),
-        ui_.get()->userphraseView, SLOT(remove())
-    );
-
-    deleteBox.exec();
+        QMessageBox deleteBox(this);
+        deleteBox.setWindowTitle(tr("Delete phrase"));
+        deleteBox.setText(text);
+        deleteBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+        deleteBox.setDefaultButton(QMessageBox::No);
+    
+        connect(
+            deleteBox.button(QMessageBox::Yes), SIGNAL(clicked()),
+            ui_.get()->userphraseView, SLOT(remove())
+        );
+    
+        deleteBox.exec();
+    }
 }
 
 void ChewingEditor::setupFileSelection()

--- a/src/view/ChewingEditor.cpp
+++ b/src/view/ChewingEditor.cpp
@@ -193,22 +193,22 @@ void ChewingEditor::showAbout()
 
 void ChewingEditor::showDeleteConfirmWindow()
 {
-    if (model_->rowCount()){
-        QString text = tr("Do you want to delete this phrase?");
+    if ( !model_->rowCount() ) return;
+    
+    QString text = tr("Do you want to delete this phrase?");
 
-        QMessageBox deleteBox(this);
-        deleteBox.setWindowTitle(tr("Delete phrase"));
-        deleteBox.setText(text);
-        deleteBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-        deleteBox.setDefaultButton(QMessageBox::No);
+    QMessageBox deleteBox(this);
+    deleteBox.setWindowTitle(tr("Delete phrase"));
+    deleteBox.setText(text);
+    deleteBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+    deleteBox.setDefaultButton(QMessageBox::No);
     
-        connect(
-            deleteBox.button(QMessageBox::Yes), SIGNAL(clicked()),
-            ui_.get()->userphraseView, SLOT(remove())
-        );
+    connect(
+        deleteBox.button(QMessageBox::Yes), SIGNAL(clicked()),
+        ui_.get()->userphraseView, SLOT(remove())
+    );
     
-        deleteBox.exec();
-    }
+    deleteBox.exec();
 }
 
 void ChewingEditor::setupFileSelection()


### PR DESCRIPTION
When I don't have phrase in editor, the remove button should be disabled.

I let the editor check quantity of phrase. If it is zero, I will disable the delete confirmation windows.