### PR TITLE
Fix #169 to catch the ambiguity word correctly

### DIFF
--- a/src/model/UserphraseModel.cpp
+++ b/src/model/UserphraseModel.cpp
@@ -194,8 +194,8 @@ void UserphraseModel::exportUserphrase(std::shared_ptr<UserphraseExporter> expor
 QString UserphraseModel::checkBopomofo(const QString &bopomofo) const
 {
     QString replaceBopomofo = bopomofo;
-    replaceBopomofo.replace(QString::fromUtf8("ㄧ"),QString::fromUtf8("ㄧ"));
-    replaceBopomofo.replace(QString::fromUtf8("Y"),QString::fromUtf8("ㄚ"));
+    replaceBopomofo.replace(QString::fromUtf8("一"),QString::fromUtf8("ㄧ"));
+    replaceBopomofo.replace(QString::fromUtf8("丫"),QString::fromUtf8("ㄚ"));
 
     return replaceBopomofo;
 }


### PR DESCRIPTION
Replacing `一` into `ㄧ` and `丫` into `ㄚ` correctly.