### PR TITLE
Fixed checkBopomofo() mis-typed by modifying 'ㄧ' into '一'

### DIFF
--- a/src/model/UserphraseModel.cpp
+++ b/src/model/UserphraseModel.cpp
@@ -194,7 +194,7 @@ void UserphraseModel::exportUserphrase(std::shared_ptr<UserphraseExporter> expor
 QString UserphraseModel::checkBopomofo(const QString &bopomofo) const
 {
     QString replaceBopomofo = bopomofo;
-    replaceBopomofo.replace(QString::fromUtf8("ㄧ"),QString::fromUtf8("ㄧ"));
+    replaceBopomofo.replace(QString::fromUtf8("一"),QString::fromUtf8("ㄧ"));
     replaceBopomofo.replace(QString::fromUtf8("Y"),QString::fromUtf8("ㄚ"));
 
     return replaceBopomofo;

--- a/src/model/UserphraseModel.cpp
+++ b/src/model/UserphraseModel.cpp
@@ -195,6 +195,7 @@ QString UserphraseModel::checkBopomofo(const QString &bopomofo) const
 {
     QString replaceBopomofo = bopomofo;
     replaceBopomofo.replace(QString::fromUtf8("一"),QString::fromUtf8("ㄧ"));
+    replaceBopomofo.replace(QString::fromUtf8("丫"),QString::fromUtf8("ㄚ"));
     replaceBopomofo.replace(QString::fromUtf8("Y"),QString::fromUtf8("ㄚ"));
 
     return replaceBopomofo;


### PR DESCRIPTION
chewing-editor expects when I type
```
phrase = "你好"
bopomofo = "ㄋ一ˇ ㄏㄠˇ"
```

will check the bopomofo and turn into

```
phrase = "你好"
bopomofo = "ㄋㄧˇ(`U+3127`) ㄏㄠˇ"
```

By changing bopomofo-like character "一"(`U+4E00`) into "ㄧ"(`U+3127`).

But mis-typed the character take this feature down.

This commit fixes this.