### PR TITLE
Use Qt5LinguistTools instead of using qtchooser (with linguist tools)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,12 +49,6 @@ install:
           # Qt
           brew link --force qt5
           ln -s /usr/local/Cellar/qt5/5.6.0/mkspecs /usr/local/mkspecs && ln -s /usr/local/Cellar/qt5/5.6.0/plugins /usr/local/plugins
-
-          # qtchooser
-          cd "$HOME"
-          git clone --depth 1 https://code.qt.io/qt/qtchooser.git && cd qtchooser
-          make -j2 && sudo make install
-          qtchooser -install 5 /usr/local/bin/qmake
       fi
     - ccache -V && ccache --show-stats && ccache --zero-stats && export use_ccache=true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
           pip install --user cpp-coveralls
           sudo add-apt-repository --yes ppa:chewing/chewing
           sudo apt-get update
-          sudo apt-get install --yes cmake help2man qt5-default qttools5-dev-tools libchewing3-dev
+          sudo apt-get install --yes cmake help2man qt5-default qttools5-dev qttools5-dev-tools libchewing3-dev
           gcc --version
           g++ --version
           gcov --version
@@ -41,19 +41,22 @@ install:
           export CC=gcc-4.8 CXX=g++-4.8
 
           # dependencies
-          brew update > /dev/null && brew install ccache libchewing cmake qt5
+          brew update > /dev/null && brew install ccache libchewing cmake qt5 gcc@4.8
 
           # ccache
           export PATH="/usr/local/opt/ccache/libexec:$PATH"
 
           # Qt
           brew link --force qt5
-          ln -s /usr/local/Cellar/qt5/5.6.0/mkspecs /usr/local/mkspecs && ln -s /usr/local/Cellar/qt5/5.6.0/plugins /usr/local/plugins
+          brew linkapps qt5
+          export HOMEBREW_QT5_VERSION=$(brew list --versions qt5 | rev | cut -d' ' -f1 | rev)
+          ln -s /usr/local/Cellar/qt5/$HOMEBREW_QT5_VERSION/mkspecs /usr/local/mkspecs && ln -s /usr/local/Cellar/qt5/$HOMEBREW_QT5_VERSION/plugins /usr/local/plugins
       fi
     - ccache -V && ccache --show-stats && ccache --zero-stats && export use_ccache=true
 
 script:
     - cd "$TRAVIS_BUILD_DIR"
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CMAKE_PREFIX_PATH=$(brew --prefix qt5)/lib/cmake; fi
     - cmake $OPTION .
     - make -j2
     - make -j2 check

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,11 +47,7 @@ add_definitions(-DTESTDATA="${PROJECT_SOURCE_DIR}/test/data")
 
 find_package(PkgConfig)
 find_package(Qt5Widgets REQUIRED)
-
-find_program(QTCHOOSER qtchooser)
-if (NOT QTCHOOSER)
-    message(SEND_ERROR "Cannot find qtchooser")
-endif()
+find_package(Qt5LinguistTools)
 
 # libchewing
 # MODIFY IF NEEDED, e.g. ${CMAKE_CURRENT_SOURCE_DIR}/libchewing/lib/*.lib
@@ -139,7 +135,7 @@ foreach(TRANSLATION ${TRANSLATION_LIST})
     set(QM_FILE "${QM_DIR}/${CMAKE_PROJECT_NAME}_${TRANSLATION}.qm")
 
     add_custom_target("${TRANSLATION}-ts"
-        COMMAND ${QTCHOOSER} -run-tool=lupdate -qt=${QT_VERSION} -${PROJECT_SOURCE_DIR}/src -ts ${TS_FILE}
+        COMMAND ${Qt5_LUPDATE_EXECUTABLE} ${PROJECT_SOURCE_DIR}/src -ts ${TS_FILE}
         DEPENDS prepare_lupdate
     )
     add_dependencies(lupdate "${TRANSLATION}-ts")
@@ -147,7 +143,7 @@ foreach(TRANSLATION ${TRANSLATION_LIST})
     add_custom_command(
         OUTPUT
             ${QM_FILE}
-        COMMAND ${QTCHOOSER} -run-tool=lrelease -qt=${QT_VERSION} ${TS_FILE} -qm ${QM_FILE}
+        COMMAND ${Qt5_LRELEASE_EXECUTABLE} ${TS_FILE} -qm ${QM_FILE}
         DEPENDS
             prepare_lrelease
             ${TS_FILE}


### PR DESCRIPTION
Fixed #203. Fixed #215.

Since we only support Qt5 now, we can use `find_package(Qt5LinguistTools)` to handle `lupdate` and `lrelease` without `qtchooser`. This could fix #203, and this must fix #215, too.