### PR TITLE
add feature: user should not change the pronunciation of an alphabet

### DIFF
--- a/src/model/UserphraseModel.cpp
+++ b/src/model/UserphraseModel.cpp
@@ -203,6 +203,16 @@ QString UserphraseModel::checkBopomofo(const QString &bopomofo) const
 void UserphraseModel::add(const QString &phrase, const QString &bopomofo)
 {
     QString replaceBopomofo = checkBopomofo(bopomofo);
+
+    const QString BopomofoRange(QString::fromUtf8("ㄅㄩ"));
+    if ( phrase.size() == 1 && replaceBopomofo.size() == 1 && phrase[0] != replaceBopomofo[0]
+            && phrase[0] >= BopomofoRange[0] && phrase[0] <= BopomofoRange[1] ){
+        qWarning() << "trying to modify the pronunciation of an alphabet!";
+        refresh();
+        emit addNewPhraseFailed();
+        return;
+    }
+
     auto ret = chewing_userphrase_add(
         ctx_.get(),
         phrase.toUtf8().constData(),


### PR DESCRIPTION
I add the feature discussing in [#79](https://github.com/chewing/chewing-editor/issues/79).

Just check if the size of phrase and bopomofo are both 1, and also they are not the same,
then the phrase shouldn't be a bopomofo.