### PR TITLE
Let undo can restore multiple pharses at one time

### DIFF
--- a/src/model/UserphraseModel.cpp
+++ b/src/model/UserphraseModel.cpp
@@ -94,7 +94,8 @@ void UserphraseModel::remove(QModelIndexList indexList)
     auto last = indexList.first().row();
 
     emit beginRemoveRows(indexList.first().parent(), first, last);
-
+	
+	int remove_cnt = 0;
     foreach(auto item, indexList) {
         auto index = item.row();
 
@@ -106,14 +107,15 @@ void UserphraseModel::remove(QModelIndexList indexList)
             userphrase_[index].bopomofo_.toUtf8().constData());
         if (ret > 0) {
             removerecord_.push_back(Userphrase{userphrase_[index]});
-            // FIXME: std::vector::erase is an inefficient operation.
+            remove_cnt++;
+			// FIXME: std::vector::erase is an inefficient operation.
             userphrase_.erase(userphrase_.begin() + index);
         } else {
             qWarning() << "chewing_userphrase_remove() returns" << ret;
         }
         // FIXME: Handle chewing_userphrase_remove fails.
     }
-
+	maxundocnt = remove_cnt;
     emit endRemoveRows();
 
     emit removePhraseCompleted(indexList.size());
@@ -232,11 +234,14 @@ const Userphrase *UserphraseModel::getUserphrase(const QModelIndex& idx)
 
 void UserphraseModel::undo()
 {
-    if (!removerecord_.empty()) {
-        auto last = removerecord_.end() - 1;
-        const QString phrase = last->display_;
-        add(last->phrase_, last->bopomofo_);
-        removerecord_.erase(last);
-        emit undoCompleted(phrase);
+    if (!removerecord_.empty() && maxundocnt>0) {
+		while(maxundocnt--){
+			auto last = removerecord_.end() - 1;
+			const QString phrase = last->display_;
+			add(last->phrase_, last->bopomofo_);
+			removerecord_.erase(last);
+			emit undoCompleted(phrase);
+		}
+		maxundocnt = 1;
     }
 }

--- a/src/model/UserphraseModel.h
+++ b/src/model/UserphraseModel.h
@@ -77,4 +77,5 @@ private:
     UserphraseSet userphrase_;
     std::vector<Userphrase> removerecord_;
     int addresult_;
+	int maxundocnt;
 };


### PR DESCRIPTION
I add some code to fix [#213](https://github.com/chewing/chewing-editor/issues/213).
If we removed multiple pharses at one time, and we want to undo that.
We only can restore single pharse many times in the past.
Now we can restore them in one time.

