### PR TITLE
Make man pages reproducible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,7 +237,7 @@ if (HELP2MAN)
             OUTPUT
                 ${manpage}.gz
             COMMAND ${GZIP}
-                -f
+                -n -f
                 ${manpage}
             DEPENDS
                 ${manpage}


### PR DESCRIPTION
By default gzip embeds the last modified time of the original file,
which makes the compressed file unreproducible. `-n` prevents that.

