### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: cpp
 os:
     - linux
     - osx
+arch: 
+    - amd64
+    - ppc64le
 
 env:
     matrix:


### PR DESCRIPTION
Thank you for your code.
Add support for architecture ppc64le.
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3 