### PR TITLE
build: add upper bound to cmake_minimum_required version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ chewing-editor.dSYM/
 chewing-editor.app/
 
 Testing/
+/build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@
 set(CMAKE_USER_MAKE_RULES_OVERRIDE	${CMAKE_CURRENT_SOURCE_DIR}/cmake/c_flag_overrides.cmake)
 set(CMAKE_USER_MAKE_RULES_OVERRIDE_CXX	${CMAKE_CURRENT_SOURCE_DIR}/cmake/cxx_flag_overrides.cmake)
 
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.0.0...3.31.6)
 project(chewing-editor VERSION 0.1.1)
 
 cmake_policy(SET CMP0020 NEW)


### PR DESCRIPTION
References
- https://bugzilla.redhat.com/show_bug.cgi?id=2380494
- https://fedoraproject.org/wiki/Changes/CMake4.0